### PR TITLE
Ignore patern for .wget-hsts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # history files
 **hst
+**hsts
 **hist**
 **HIST**
 


### PR DESCRIPTION
Noticed that the wget history file slipped through existing pattern, added to correct.