### PR TITLE
Add code quality diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -212,6 +212,8 @@ dotnet_diagnostic.CA2200.severity = warning
 dotnet_diagnostic.CA2201.severity = warning
 dotnet_diagnostic.CA2208.severity = warning
 dotnet_diagnostic.CA2234.severity = warning
+dotnet_diagnostic.CA2218.severity = warning
+dotnet_diagnostic.CA2224.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -208,6 +208,9 @@ dotnet_diagnostic.CA3003.severity = warning
 dotnet_diagnostic.CA3004.severity = warning
 dotnet_diagnostic.CA3006.severity = warning
 dotnet_diagnostic.CA3007.severity = warning
+dotnet_diagnostic.CA2200.severity = warning
+dotnet_diagnostic.CA2201.severity = warning
+dotnet_diagnostic.CA2208.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,9 @@ dotnet_diagnostic.IDE0052.severity = warning
 dotnet_diagnostic.IDE0055.severity = none
 dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0079.severity = warning
+dotnet_diagnostic.IDE0076.severity = warning
+dotnet_diagnostic.IDE0077.severity = warning
+dotnet_diagnostic.IDE0050.severity = none
 
 ; Manage specific RCS refactoring settings
 dotnet_diagnostic.RCS1138.severity  = warning
@@ -198,25 +201,22 @@ dotnet_diagnostic.RCS1248.severity  = suggestion
 dotnet_diagnostic.RCS1007.severity  = warning
 
 ; Manage specific CA refactoring settings
-dotnet_diagnostic.CA1041.severity  = warning
-dotnet_diagnostic.CA1054.severity  = warning
-dotnet_diagnostic.CA1055.severity  = warning
-dotnet_diagnostic.CA1056.severity  = warning
-dotnet_diagnostic.CA2100.severity  = warning
-dotnet_diagnostic.CA3001.severity  = warning
-dotnet_diagnostic.CA3003.severity  = warning
-dotnet_diagnostic.CA3004.severity  = warning
-dotnet_diagnostic.CA3006.severity  = warning
-dotnet_diagnostic.CA3007.severity  = warning
-dotnet_diagnostic.CA2200.severity  = warning
-dotnet_diagnostic.CA2201.severity  = warning
-dotnet_diagnostic.CA2208.severity  = warning
-dotnet_diagnostic.CA2234.severity  = warning
-dotnet_diagnostic.CA2218.severity  = warning
-dotnet_diagnostic.CA2224.severity  = warning
-dotnet_diagnostic.IDE0076.severity = warning
-dotnet_diagnostic.IDE0077.severity = warning
-dotnet_diagnostic.IDE0050.severity = none
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_diagnostic.CA1054.severity = warning
+dotnet_diagnostic.CA1055.severity = warning
+dotnet_diagnostic.CA1056.severity = warning
+dotnet_diagnostic.CA2100.severity = warning
+dotnet_diagnostic.CA3001.severity = warning
+dotnet_diagnostic.CA3003.severity = warning
+dotnet_diagnostic.CA3004.severity = warning
+dotnet_diagnostic.CA3006.severity = warning
+dotnet_diagnostic.CA3007.severity = warning
+dotnet_diagnostic.CA2200.severity = warning
+dotnet_diagnostic.CA2201.severity = warning
+dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.CA2234.severity = warning
+dotnet_diagnostic.CA2218.severity = warning
+dotnet_diagnostic.CA2224.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -198,22 +198,24 @@ dotnet_diagnostic.RCS1248.severity  = suggestion
 dotnet_diagnostic.RCS1007.severity  = warning
 
 ; Manage specific CA refactoring settings
-dotnet_diagnostic.CA1041.severity = warning
-dotnet_diagnostic.CA1054.severity = warning
-dotnet_diagnostic.CA1055.severity = warning
-dotnet_diagnostic.CA1056.severity = warning
-dotnet_diagnostic.CA2100.severity = warning
-dotnet_diagnostic.CA3001.severity = warning
-dotnet_diagnostic.CA3003.severity = warning
-dotnet_diagnostic.CA3004.severity = warning
-dotnet_diagnostic.CA3006.severity = warning
-dotnet_diagnostic.CA3007.severity = warning
-dotnet_diagnostic.CA2200.severity = warning
-dotnet_diagnostic.CA2201.severity = warning
-dotnet_diagnostic.CA2208.severity = warning
-dotnet_diagnostic.CA2234.severity = warning
-dotnet_diagnostic.CA2218.severity = warning
-dotnet_diagnostic.CA2224.severity = warning
+dotnet_diagnostic.CA1041.severity  = warning
+dotnet_diagnostic.CA1054.severity  = warning
+dotnet_diagnostic.CA1055.severity  = warning
+dotnet_diagnostic.CA1056.severity  = warning
+dotnet_diagnostic.CA2100.severity  = warning
+dotnet_diagnostic.CA3001.severity  = warning
+dotnet_diagnostic.CA3003.severity  = warning
+dotnet_diagnostic.CA3004.severity  = warning
+dotnet_diagnostic.CA3006.severity  = warning
+dotnet_diagnostic.CA3007.severity  = warning
+dotnet_diagnostic.CA2200.severity  = warning
+dotnet_diagnostic.CA2201.severity  = warning
+dotnet_diagnostic.CA2208.severity  = warning
+dotnet_diagnostic.CA2234.severity  = warning
+dotnet_diagnostic.CA2218.severity  = warning
+dotnet_diagnostic.CA2224.severity  = warning
+dotnet_diagnostic.IDE0076.severity = warning
+dotnet_diagnostic.IDE0077.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -143,7 +143,7 @@ dotnet_diagnostic.IDE0055.severity = none
 dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0079.severity = warning
 
-; Manage specific RCS refactoring settigs
+; Manage specific RCS refactoring settings
 dotnet_diagnostic.RCS1138.severity  = warning
 dotnet_diagnostic.RCS1181.severity  = suggestion
 dotnet_diagnostic.RCS1037.severity  = warning
@@ -196,6 +196,9 @@ dotnet_diagnostic.RCS1236.severity  = suggestion
 dotnet_diagnostic.RCS1247.severity  = warning
 dotnet_diagnostic.RCS1248.severity  = suggestion
 dotnet_diagnostic.RCS1007.severity  = warning
+
+; Manage specific CA refactoring settings
+dotnet_diagnostic.CA1041.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -202,6 +202,12 @@ dotnet_diagnostic.CA1041.severity = warning
 dotnet_diagnostic.CA1054.severity = warning
 dotnet_diagnostic.CA1055.severity = warning
 dotnet_diagnostic.CA1056.severity = warning
+dotnet_diagnostic.CA2100.severity = warning
+dotnet_diagnostic.CA3001.severity = warning
+dotnet_diagnostic.CA3003.severity = warning
+dotnet_diagnostic.CA3004.severity = warning
+dotnet_diagnostic.CA3006.severity = warning
+dotnet_diagnostic.CA3007.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -211,6 +211,7 @@ dotnet_diagnostic.CA3007.severity = warning
 dotnet_diagnostic.CA2200.severity = warning
 dotnet_diagnostic.CA2201.severity = warning
 dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.CA2234.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -199,6 +199,9 @@ dotnet_diagnostic.RCS1007.severity  = warning
 
 ; Manage specific CA refactoring settings
 dotnet_diagnostic.CA1041.severity = warning
+dotnet_diagnostic.CA1054.severity = warning
+dotnet_diagnostic.CA1055.severity = warning
+dotnet_diagnostic.CA1056.severity = warning
 
 ; New line preferences
 csharp_new_line_before_catch                          = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -216,6 +216,7 @@ dotnet_diagnostic.CA2218.severity  = warning
 dotnet_diagnostic.CA2224.severity  = warning
 dotnet_diagnostic.IDE0076.severity = warning
 dotnet_diagnostic.IDE0077.severity = warning
+dotnet_diagnostic.IDE0050.severity = none
 
 ; New line preferences
 csharp_new_line_before_catch                          = true


### PR DESCRIPTION
## Resolves #98

### Changes
1. CA1041: Provide ObsoleteAttribute message
2. CA1054: URI parameters should not be strings
3. CA1055: URI return values should not be strings
4. CA1056: URI properties should not be strings
5. CA2100: Review SQL queries for security vulnerabilities
6. CA3001: Review code for SQL injection vulnerabilities
7. CA3003: Review code for file path injection vulnerabilities
8. CA3004: Review code for information disclosure vulnerabilities
9. CA3006: Review code for process command injection vulnerabilities
10. CA3007: Review code for open redirect vulnerabilities
11. CA2200: Rethrow to preserve stack details
12. CA2201: Do not raise reserved exception types
13. CA2208: Instantiate argument exceptions correctly
14. CA2234: Pass System.Uri objects instead of strings
15. CA2218: Override GetHashCode on overriding Equals
16. CA2224: Override Equals on overloading operator equals
17. IDE0076: Remove invalid global 'SuppressMessageAttribute'
18. IDE0077: Avoid legacy format target in global 'SuppressMessageAttribute'
19. IDE0050: Don't convert anonymous type to tuple

