### PR TITLE
shellcheck pfetchrc

### DIFF
--- a/.build/Makefile
+++ b/.build/Makefile
@@ -24,6 +24,7 @@ test_shellcheck: ${CHELLCHECK}
 	${SHELLCHECK} ../.aliases
 	${SHELLCHECK} ../.xinitrc
 	${SHELLCHECK} ../.xsession
+	${SHELLCHECK} ../.pfetchrc
 
 ${VIMLINT}: bin/% : lib/%
 	echo "#!/bin/sh" > $@

--- a/.build/Makefile
+++ b/.build/Makefile
@@ -24,7 +24,7 @@ test_shellcheck: ${CHELLCHECK}
 	${SHELLCHECK} ../.aliases
 	${SHELLCHECK} ../.xinitrc
 	${SHELLCHECK} ../.xsession
-	${SHELLCHECK} ../.pfetchrc
+	${SHELLCHECK} ../.pfetchrc -e SC2034
 
 ${VIMLINT}: bin/% : lib/%
 	echo "#!/bin/sh" > $@


### PR DESCRIPTION
## Resolves #124

### Changes
1. Add pfetchrc to shellcheck list
2. Since .pfetchrc is sourced, it's variables are not exported, ignore this Shellcheck warning

