### PR TITLE
[BUG]: Remove two unnecessary subshell calls.

### DIFF
--- a/.profile
+++ b/.profile
@@ -6,9 +6,9 @@
 
 # Helper to prevent errors on missing tools
 try() {
-	if [ -x "$(command -v "$1")" ]
+	if command -v "$1" >/dev/null 2>&1
 	then
-		echo "$@" | sh
+		"$@"
 	fi
 }
 


### PR DESCRIPTION
The `try()` function in `.profile` opens a new subshell to call `command` in and a second subshell through which the command is piped.

This removes both.