### PR TITLE
Create .gitattributes to overload language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Overload all C files and headers
+*.c linguist-language=C
+*.h linguist-language=C


### PR DESCRIPTION
## Resolves #139

### Changes
1. Add .gitattributes to correct linguist detection
