### PR TITLE
Don't explicitly set nocompatible

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Vint .vimrc
         uses: ludvighz/vint-action@v1
         with:
-          args: --verbose --style-problem --color
           path: .vimrc
+          args: --verbose --style-problem --color
       - uses: actions/checkout@v1
       - name: Vint .exrc
         uses: ludvighz/vint-action@v1
         with:
-          args: --verbose --style-problem --color
           path: .exrc
+          args: --verbose --style-problem --color

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -13,11 +13,9 @@ jobs:
       - name: Vint .vimrc
         uses: ludvighz/vint-action@v1
         with:
-          path: .vimrc
-          args: --verbose --style-problem --color
+          args: --verbose --style-problem --color .vimrc
       - uses: actions/checkout@v1
       - name: Vint .exrc
         uses: ludvighz/vint-action@v1
         with:
-          path: .exrc
-          args: --verbose --style-problem --color
+          args: --verbose --style-problem --color .exrc

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Vint .vimrc
         uses: ludvighz/vint-action@v1
         with:
-          args: --verbose --style-problem --color .vimrc
+          path: .vimrc
       - uses: actions/checkout@v1
       - name: Vint .exrc
         uses: ludvighz/vint-action@v1
         with:
-          args: --verbose --style-problem --color .exrc
+          path: .exrc

--- a/.vimrc
+++ b/.vimrc
@@ -5,9 +5,6 @@
 " See:     https://github/yuri-norwood/dotfiles
 "
 
-" Allow bells and whistles
-set nocompatible
-
 " Allow special characters and symbols
 set encoding=utf-8 " do this before :scriptencoding
 scriptencoding utf-8


### PR DESCRIPTION
It is the default when vim is using `.vimrc`

## Part of #102 