### PR TITLE
[NEW-90]: disable xconsole on open bsd

### DIFF
--- a/.xsetup
+++ b/.xsetup
@@ -2,5 +2,3 @@
 
 xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_weave
 
-xconsole -geometry 480x130-0-0 -daemon -notify -verbose -fn fixed -exitOnFail
-

--- a/.xsetup
+++ b/.xsetup
@@ -1,5 +1,4 @@
 #!/bin/sh
-# $OpenBSD: Xsetup_0,v 1.8 2020/07/04 13:32:50 matthieu Exp $
 
 xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_weave
 
@@ -13,4 +12,3 @@ xconsole -geometry 480x130-0-0 -daemon -notify -verbose -fn fixed -exitOnFail
 # 	/usr/local/bin/openbsd-wallpaper
 # fi
 
-# sxpm OpenBSD.xpm &

--- a/.xsetup
+++ b/.xsetup
@@ -1,0 +1,16 @@
+#!/bin/sh
+# $OpenBSD: Xsetup_0,v 1.8 2020/07/04 13:32:50 matthieu Exp $
+
+xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_weave
+
+xconsole -geometry 480x130-0-0 -daemon -notify -verbose -fn fixed -exitOnFail
+
+#  install package openbsd-backgrounds
+#  then uncomment:
+#
+# if test -x /usr/local/bin/openbsd-wallpaper
+# then
+# 	/usr/local/bin/openbsd-wallpaper
+# fi
+
+# sxpm OpenBSD.xpm &

--- a/.xsetup
+++ b/.xsetup
@@ -4,11 +4,3 @@ xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_w
 
 xconsole -geometry 480x130-0-0 -daemon -notify -verbose -fn fixed -exitOnFail
 
-#  install package openbsd-backgrounds
-#  then uncomment:
-#
-# if test -x /usr/local/bin/openbsd-wallpaper
-# then
-# 	/usr/local/bin/openbsd-wallpaper
-# fi
-


### PR DESCRIPTION
## Resolves #90 

### Changes
1. Create .xsetup as direct copy of default Xsetup_0 …
2. Remove CVS / OBSD specific comments
3. Remove installation of openbsd-backgounds …
4. Remove xconsole start up