### PR TITLE
[BUG-192]: Update label query links

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,10 +8,10 @@
 [![Code Size](https://img.shields.io/github/languages/code-size/yuri-norwood/dotfiles)](https://github.com/yuri-norwood/dotfiles)
 [![Commit Activity](https://img.shields.io/github/commit-activity/w/yuri-norwood/dotfiles)](https://github.com/yuri-norwood/dotfiles)
 [![Last Commit](https://img.shields.io/github/last-commit/yuri-norwood/dotfiles)](https://github.com/yuri-norwood/dotfiles)
-[![Visual Studio](https://img.shields.io/github/labels/yuri-norwood/dotfiles/visual%20studio?logo=visual%20studio)](https://github.com/yuri-norwood/dotfiles/labels/visual%20studio)
-[![OpenBSD](https://img.shields.io/github/labels/yuri-norwood/dotfiles/openbsd?logo=openbsd&logoColor=000)](https://github.com/yuri-norwood/dotfiles/labels/openbsd)
-[![Suckless](https://img.shields.io/github/labels/yuri-norwood/dotfiles/suckless?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8IS0tIENvcHlyaWdodCAoYykgMjAxNSwgTGFzbG8gSHVuaG9sZCA8ZGV2QGZyaWduLmRlPiAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMi41IiBoZWlnaHQ9IjE1IiB2ZXJzaW9uPSIxLjEiPgo8cGF0aCBzdHlsZT0iZmlsbDojZWVlZWVlIiBkPSJtIDAsMTUgMjIuNSwwIDAsLTkuMzc1IC0xOC43NSwwIDAsLTEuODc1IDE4Ljc1LDAgMCwtMy43NSAtMjIuNSwwIDAsOS4zNzUgMTguNzUsMCAwLDEuODc1IC0xOC43NSwwIHoiIC8+Cjwvc3ZnPgo=)](https://github.com/yuri-norwood/dotfiles/labels/suckless)
-[![Vim](https://img.shields.io/github/labels/yuri-norwood/dotfiles/vim?logo=vim)](https://github.com/yuri-norwood/dotfiles/labels/vim)
+[![Visual Studio](https://img.shields.io/github/labels/yuri-norwood/dotfiles/visual%20studio?logo=visual%20studio)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3A%22visual+studio%22)
+[![OpenBSD](https://img.shields.io/github/labels/yuri-norwood/dotfiles/openbsd?logo=openbsd&logoColor=000)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Aopenbsd)
+[![Suckless](https://img.shields.io/github/labels/yuri-norwood/dotfiles/suckless?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8IS0tIENvcHlyaWdodCAoYykgMjAxNSwgTGFzbG8gSHVuaG9sZCA8ZGV2QGZyaWduLmRlPiAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMi41IiBoZWlnaHQ9IjE1IiB2ZXJzaW9uPSIxLjEiPgo8cGF0aCBzdHlsZT0iZmlsbDojZWVlZWVlIiBkPSJtIDAsMTUgMjIuNSwwIDAsLTkuMzc1IC0xOC43NSwwIDAsLTEuODc1IDE4Ljc1LDAgMCwtMy43NSAtMjIuNSwwIDAsOS4zNzUgMTguNzUsMCAwLDEuODc1IC0xOC43NSwwIHoiIC8+Cjwvc3ZnPgo=)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Asuckless)
+[![Vim](https://img.shields.io/github/labels/yuri-norwood/dotfiles/vim?logo=vim)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Avim)
 
 Configuration files and various customizations.
 


### PR DESCRIPTION
## Resolves #192 

### Changes
1. Updated the urls that the label badges link to, change the query to **not** restrict to open issues and pulls only.