### PR TITLE
[BUG-237]: Remove .vs from labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,6 +69,3 @@ vim:
   - '.vim/**/*'
   - '.vim/pack/**/*'
   - '**/*.vim'
-
-# This affects Visual Studio (or VS-Code)
-visual studio: '.vs/**'


### PR DESCRIPTION
# Resolves #237

Note: This removes the visual studio label, it may be re-added in the future
