### PR TITLE
[BUG-263]: Extend JS indentation rule to include HTML and CSS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,8 +43,8 @@ end_of_line  = crlf
 [.vimrc]
 trim_trailing_whitespace = false
 
-; JavaScript should be indented with spaces
-[*.js]
+; Web files should be indented with spaces
+[*.{html,htm,css,js}]
 indent_style = space
 indent_size  = 4
 

--- a/.surf/styles/startpage.com.css
+++ b/.surf/styles/startpage.com.css
@@ -4,5 +4,5 @@
 #bottom-result-container #spon_links,
 #bottom-result-container #sponsored_csa1,
 #bottom-result-container #sponsored_csa2 {
-	display: none !important;
+    display: none !important;
 }


### PR DESCRIPTION
# Resolves #263
