### PR TITLE
[MOD-317]: Disable JS syntax based folding in vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -116,8 +116,3 @@ let g:javascript_plugin_jsdoc = 1
 let g:javascript_plugin_ngdoc = 1
 let g:javascript_plugin_flow  = 1
 
-augroup javascript_plugin_folding
-	autocmd!
-	autocmd FileType javascript setlocal foldmethod=syntax
-augroup END
-


### PR DESCRIPTION
# Resolves  #317