### PR TITLE
[BUG-335]: Correct `include()` function

### DIFF
--- a/.profile
+++ b/.profile
@@ -17,7 +17,7 @@ try() {
 include() {
 	if [ -f "$1" ]
 	then
-		. ~/.aliases
+		. "$1"
 	fi
 }
 


### PR DESCRIPTION
# Resolves #335