### PR TITLE
[MOD-376]: Change protected naming rules from private to public group

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -278,7 +278,7 @@ csharp_preserve_single_line_statements = true
 
 ; Define `public` symbols
 dotnet_naming_symbols.public.applicable_kinds           = class, struct, interface, enum, property, method, field, event, delegate
-dotnet_naming_symbols.public.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public.applicable_accessibilities = public, internal, protected, protected_internal
 
 ; Define `pascal` style
 dotnet_naming_style.pascal.capitalization = pascal_case
@@ -290,7 +290,7 @@ dotnet_naming_rule.public_members_pascal.severity = warning
 
 ; Define `private` symbols
 dotnet_naming_symbols.private.applicable_kinds           = class, struct, interface, enum, property, method, field, event, delegate
-dotnet_naming_symbols.private.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private.applicable_accessibilities = private, private_protected
 
 ; Define `camel` style
 dotnet_naming_style.camel.capitalization = camel_case


### PR DESCRIPTION
# Resolves #376
See:
* https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/private-protected
* https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/protected-internal