### PR TITLE
[MOD-412]: Make labels link to specific configurations

### DIFF
--- a/.config/X11/xdm/Xsetup_0
+++ b/.config/X11/xdm/Xsetup_0
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_weave
-

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-[![Vim](https://img.shields.io/badge/--019733?logo=vim)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Avim)
+[![Vim](https://img.shields.io/badge/--019733?logo=vim)](../.vimrc)
 [![OpenBSD](https://img.shields.io/badge/--F2CA30?logo=openbsd&logoColor=000000)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Aopenbsd)
 [![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Asuckless)
 [![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Adwm)

--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 [![Vim](https://img.shields.io/badge/--019733?logo=vim)](../.vimrc)
 [![OpenBSD](https://img.shields.io/badge/--F2CA30?logo=openbsd&logoColor=000000)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Aopenbsd)
 [![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](../.local/share/suckless)
-[![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Adwm)
+[![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](../.local/share/suckless/dwm)
 [![git](https://img.shields.io/badge/--F05032?logo=git&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Agit)
 [![x11](https://img.shields.io/badge/--F28834?logo=x.org&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ax11)
 [![Visual Studio](https://img.shields.io/badge/--6C33AF?logo=visual%20studio)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3A%22visual+studio%22)

--- a/.github/README.md
+++ b/.github/README.md
@@ -5,7 +5,7 @@
 [![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](../.local/share/suckless)
 [![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](../.local/share/suckless/dwm)
 [![git](https://img.shields.io/badge/--F05032?logo=git&logoColor=ffffff)](../.config/git)
-[![x11](https://img.shields.io/badge/--F28834?logo=x.org&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ax11)
+[![x11](https://img.shields.io/badge/--F28834?logo=x.org&logoColor=ffffff)](../.config/X11)
 [![Visual Studio](https://img.shields.io/badge/--6C33AF?logo=visual%20studio)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3A%22visual+studio%22)
 [![Go](https://img.shields.io/badge/--00ADD8?logo=go&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ago)
 [![Sponsors](https://img.shields.io/badge/--EA4AAA?logo=github-sponsors&logoColor=ffffff)](https://github.com/sponsors/yuri-norwood)

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 [![Vim](https://img.shields.io/badge/--019733?logo=vim)](../.vimrc)
 [![OpenBSD](https://img.shields.io/badge/--F2CA30?logo=openbsd&logoColor=000000)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Aopenbsd)
-[![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Asuckless)
+[![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](../.local/share/suckless)
 [![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Adwm)
 [![git](https://img.shields.io/badge/--F05032?logo=git&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Agit)
 [![x11](https://img.shields.io/badge/--F28834?logo=x.org&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ax11)

--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
 [![OpenBSD](https://img.shields.io/badge/--F2CA30?logo=openbsd&logoColor=000000)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Aopenbsd)
 [![Suckless](https://img.shields.io/badge/--1177AA?logo=suckless)](../.local/share/suckless)
 [![dwm](https://img.shields.io/badge/--1177AA?logo=dwm)](../.local/share/suckless/dwm)
-[![git](https://img.shields.io/badge/--F05032?logo=git&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Agit)
+[![git](https://img.shields.io/badge/--F05032?logo=git&logoColor=ffffff)](../.config/git)
 [![x11](https://img.shields.io/badge/--F28834?logo=x.org&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ax11)
 [![Visual Studio](https://img.shields.io/badge/--6C33AF?logo=visual%20studio)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3A%22visual+studio%22)
 [![Go](https://img.shields.io/badge/--00ADD8?logo=go&logoColor=ffffff)](https://github.com/yuri-norwood/dotfiles/issues?q=label%3Ago)


### PR DESCRIPTION
# Resolves  #412

## Changes

1. Link vim badge to vimrc
2. Link suckless badge to .local/share/suckless
3. Link dwm badge to .local/share/suckless/dwm
4. Link git badge to gitconfig
5. Link x11 badge to .config/X11
