### PR TITLE
[MOD-412]: Move .config/xenodm/Xsetup_0 to .config/X11/xdm/Xsetup_0

### DIFF
--- a/.config/X11/xdm/Xsetup_0
+++ b/.config/X11/xdm/Xsetup_0
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 xsetroot -fg \#6f6f6f -bg \#bfbfbf -bitmap /usr/X11R6/include/X11/bitmaps/root_weave
-


### PR DESCRIPTION
Resolves #412

This means that the file structure matches the /etc/X11/xdm path on OpenBSD