### PR TITLE
[BUG-424]: Fix labeler paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,7 +43,7 @@ js:
 
 # This regards the Korn Shell
 ksh:
-  - '.kshrc'
+  - '.config/ksh/kshrc'
   - '**/*.ksh'
 
 # This regards the labeler automation

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,10 +98,10 @@ test:
 
 # This regards vim or vimscript
 vim:
-  - '.exrc'
-  - '.vimrc'
-  - '.vim/**/*'
-  - '.vim/pack/**/*'
+  - '.config/vim/exrc'
+  - '.config/vim/vimrc'
+  - '.config/vim/**/*'
+  - '.config/vim/pack/**/*'
   - '**/*.vim'
 
 # This regards Xorg or X11

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -107,6 +107,4 @@ vim:
 # This regards Xorg or X11
 x11:
   - '.config/X11/**/*'
-  - '.config/xenodm/**/*'
-  - '.xinitrc'
-  - '.xsession'
+  - '.config/X11/xdm/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,7 +55,7 @@ openbsd:
   - '**/openbsd/**/*'
   - '.config/doas/**/*'
   - '.config/xenodm/**/*'
-  - '.kshrc'
+  - '.config/ksh/kshrc'
   - '**/*.ksh'
 
 # This regards the UNIX shell environment
@@ -63,7 +63,7 @@ shell:
   - '**/*.sh'
   - '**/*.ksh'
   - '.profile'
-  - '.kshrc'
+  - '.config/ksh/kshrc'
 
 # GitHub sponsors
 sponsor:


### PR DESCRIPTION
# Resolves #424

## Changes

1. Fix obsd and shell labels using kshrc path
2. Fix vim label paths
3. Fix X11 / Xorg label paths