### PR TITLE
[BUG-365]: Explicit st(1) regex is not needed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,5 @@
 .local/share/suckless/*/colours/*.c linguist-language=C
 .local/share/suckless/*/colours/*.h linguist-language=C
 
-# Satisfy st(1) colourschemes explicitly
-.local/share/suckless/st/colours/*.c linguist-language=C
-.local/share/suckless/st/colours/*.h linguist-language=C
-
 # Correct yaml lint file type (missing extension by design)
 .config/yamllint/config lingust-language=YAML


### PR DESCRIPTION
GitHub only shows the incorrect type due to the long lived index cache.

See #365