### PR TITLE
[BUG-439]: kshrc HISTFILE may conflict between formats

### DIFF
--- a/.config/ksh/kshrc
+++ b/.config/ksh/kshrc
@@ -14,7 +14,7 @@ case "$0" in
 esac
 
 # Configure history
-HISTFILE="${XDG_CACHE_HOME}/history.ksh"
+HISTFILE="${XDG_CACHE_HOME}/history.$(basename "$0")"
 HISTSIZE=2048
 
 # Use Emacs line editing for arrow and home / end keys to work


### PR DESCRIPTION
# Resolves #439

## Changes

1. Get history file extension from invocation path