### PR TITLE
[BUG-444]: Documentation label missed for vim package READMEs

### DIFF
--- a/.config/vim/.gitignore
+++ b/.config/vim/.gitignore
@@ -1,2 +1,0 @@
-# Vim specific ignore files
-spell**

--- a/.config/vim/pack/c/start/README.md
+++ b/.config/vim/pack/c/start/README.md
@@ -1,3 +1,3 @@
 # Vim C / C++ Plugins
 
-* extras - Syntax enhancements for C, Bison, and Flex
+* extras - Syntax enhancements for C/C++, Bison, and Flex

--- a/.config/vim/spell/.gitignore
+++ b/.config/vim/spell/.gitignore
@@ -1,0 +1,2 @@
+# Ignore spell files as they may contain sensitive information
+*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,7 +16,7 @@ documentation:
   - '.github/CODEOWNERS'
   - '.github/ISSUE_TEMPLATE/config.yml'
   - '.gitattributes'
-  - '.vim/pack/*/start/README.md'
+  - '.config/vim/pack/**/README.md'
 
 # http://dwm.suckless.org/
 dwm:


### PR DESCRIPTION
# Resolves #444

## Changes

1. Update labeler config
2. Make some dummy changes to trigger test