### PR TITLE
[MOD-447]: Add editorconfig for go

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,19 +10,20 @@ charset                  = utf-8
 trim_trailing_whitespace = true
 insert_final_newline     = true
 
+; Go
+[*.go]
+indent_style             = tab
+indent_size              = 4
+charset                  = utf-8
+trim_trailing_whitespace = true
+
 ; Modern markup langs
 [*.{md,yml,json}]
 indent_style = space
 indent_size  = 2
 
 ; Makefiles
-[{M,m}akefile]
-indent_style = tab
-indent_size  = 8
-end_of_line  = lf
-
-; Makefile includes
-[*.mk]
+[{M,m}akefile,*.mk]
 indent_style = tab
 indent_size  = 8
 end_of_line  = lf
@@ -60,7 +61,7 @@ indent_style = space
 indent_size  = 2
 
 ; Dotnet files
-[*{cs,vb}]
+[*.{cs,vb}]
 indent_style = space
 indent_size  = 4
 end_of_line  = unset


### PR DESCRIPTION
# Resolves #447

## Changes

1. Add rule to editorconfig for *.go
2. Remove duplicate section for *.mk
3. Add missing dot to C# and VB section