### PR TITLE
[BUG-462]: Substituting ssh url for github breaks submodules

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -44,5 +44,3 @@
 	recurse   = true
 	fetchJobs = 8
 
-[url "ssh:github.com/"]
-	insteadOf = https://github.com/


### PR DESCRIPTION
# Resolves #462