### PR TITLE
[BUG-497]: Repo URL is hardcoded use ${{GITHUB_REPOSITORY}}

### DIFF
--- a/.github/workflows/issue_automation.yml
+++ b/.github/workflows/issue_automation.yml
@@ -27,7 +27,7 @@ jobs:
           ref: main
       - name: Auto branch
         run: |
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/yuri-norwood/dotfiles.git
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ GITHUB_REPOSITORY }}.git
           git checkout -b "${{ env.GITHUB_NEW_BRANCH }}"
           git push -u origin "${{ env.GITHUB_NEW_BRANCH }}"
 


### PR DESCRIPTION
# Resolves  #497

These workflows are as much .dotfiles as anything else in this repo, so this needs to be general.