### PR TITLE
[BUG-515]: Fix link in checkout comment

### DIFF
--- a/.github/workflows/issue_automation.yml
+++ b/.github/workflows/issue_automation.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Set env
         run: |
           echo "GITHUB_NEW_BRANCH=$(echo '${{ github.event.issue.number }} ${{ github.event.issue.title }}' | tr -Cs '[:alnum:]\n' '-' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
 
       # Create new branch and push to remote
       - uses: actions/checkout@v2
@@ -27,7 +28,7 @@ jobs:
           ref: main
       - name: Auto branch
         run: |
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ env.GITHUB_REPOSITORY }}.git
           git checkout -b "${{ env.GITHUB_NEW_BRANCH }}"
           git push -u origin "${{ env.GITHUB_NEW_BRANCH }}"
 
@@ -36,7 +37,7 @@ jobs:
         uses: KeisukeYamashita/create-comment@v1
         with:
           comment: |
-            https://github.com/${GITHUB_REPOSITORY}/tree/${{ env.GITHUB_NEW_BRANCH }}
             ```sh
             git fetch && git checkout "${{ env.GITHUB_NEW_BRANCH }}"
             ```
+            ([Go to branch](https://github.com/${{ env.GITHUB_REPOSITORY }}/tree/${{ env.GITHUB_NEW_BRANCH }}))


### PR DESCRIPTION
# Resolves #516

I figured out what was happening, the `${GITHUB_REPOSITORY}` variable is a *shell* variable, not to be confused with the *action* variable `${{ env.GITHUB_NEW_BRANCH }}`.