### PR TITLE
[HUB-539]: Yaml linter config file should have yml extension

### DIFF
--- a/.config/yamllint/.editorconfig
+++ b/.config/yamllint/.editorconfig
@@ -1,7 +1,0 @@
-; Inherit global rules
-root = false
-
-; Apply YMAL rules to the config files (missing extension)
-[config]
-indent_style = space
-indent_size  = 2

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -113,6 +113,6 @@ x11:
   - '.config/X11/**/*'
   - '.config/X11/xdm/**/*'
 
-# This regards the labeler automation
+# This regards the yamllint automation
 yamllint:
   - '.github/yamllint.yml'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -112,3 +112,7 @@ vim:
 x11:
   - '.config/X11/**/*'
   - '.config/X11/xdm/**/*'
+
+# This regards the labeler automation
+yamllint:
+  - '.github/yamllint.yml'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -58,18 +58,8 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
         with:
           strict: true
-          config_file: .config/yamllint/config
+          config_file: .github/yamllint.yml
           format: parsable
-
-      # Lint yamllint config
-      - uses: actions/checkout@v1
-      - name: yaml lint config
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          strict: true
-          config_file: .config/yamllint/config
-          format: parsable
-          file_or_dir: .config/yamllint/config
 
   # This job checks that all files match the rules in the .editorconfig
   editorconfig:

--- a/.github/yamllint.yml
+++ b/.github/yamllint.yml
@@ -1,5 +1,3 @@
-# vim: set ft=yml:
-
 ---
 
 # This file defines configurations on how to lint yaml files


### PR DESCRIPTION
# Resolves #539

## Changes

1. Move .config/yamllint/config to .github/yamllint.yml
2. Update yamllint action steps to use new path
3. Remove .config/yamllint/.editorconfig
4. Add yamllint label to .github/labeler.yml