### PR TITLE
[ENV-000]: Fix PS1 breaking on subshells

### DIFF
--- a/.profile
+++ b/.profile
@@ -56,7 +56,7 @@ path_add "scripts"
 path_add "pfetch"
 
 # Set the prompt to the current directory and a dollar sign
-export PS1='$(_PS1_DIR) $ '
+export PS1="$(_PS1_DIR) $ "
 
 # Set editor commands.
 export VISUAL="$(command -v vim 2>/dev/null)"


### PR DESCRIPTION
I have no idea why this fixes it, (I have some ideas), but since this fixes it no problem, and since I've been using the double quotes for this exact PS1 for years without issue, I've assuming that I've troubleshooted this before and will just go with it.

To satisfy my CI/CD workflows, I'm assigning this the issue number [#0](https://github.com/yuri-norwood/dotfiles/issues/1), no such issue exists, but it is idiomatic.