### PR TITLE
[ENV-544]: Allow implicit default .config namespace

### DIFF
--- a/.profile
+++ b/.profile
@@ -10,6 +10,8 @@ include() {
 	if [ -f "$1" ]
 	then
 		. "$1"
+	elif [ -d "${XDG_CONFIG_HOME}" ] && [ -f "${XDG_CONFIG_HOME}/$1" ]
+		. "${XDG_CONFIG_HOME}/$1"
 	fi
 }
 

--- a/.profile
+++ b/.profile
@@ -10,7 +10,7 @@ include() {
 	if [ -f "$1" ]
 	then
 		. "$1"
-	elif [ -d "${XDG_CONFIG_HOME}" ] && [ -f "${XDG_CONFIG_HOME}/$1" ]
+	elif [ -f "${XDG_CONFIG_HOME}/$1" ]
 		. "${XDG_CONFIG_HOME}/$1"
 	fi
 }

--- a/.profile
+++ b/.profile
@@ -47,9 +47,9 @@ export XDG_CACHE_HOME="${HOME}/.cache"
 export XDG_BIN_HOME="${HOME}/.local/bin"
 
 # Include alias definitions
-include "${XDG_CONFIG_HOME}/aliases/ls"
-include "${XDG_CONFIG_HOME}/aliases/mkdir"
-include "${XDG_CONFIG_HOME}/aliases/cd"
+include "aliases/ls"
+include "aliases/mkdir"
+include "aliases/cd"
 
 # Add scripts to PATH, its tools may be accessed after this
 path_add "scripts"

--- a/.profile
+++ b/.profile
@@ -11,6 +11,7 @@ include() {
 	then
 		. "$1"
 	elif [ -f "${XDG_CONFIG_HOME}/$1" ]
+	then
 		. "${XDG_CONFIG_HOME}/$1"
 	fi
 }


### PR DESCRIPTION
# Resolves #544

## Changes

1. Allow implicit `.config` namespace to be omitted
2. Change references to use implicit namespace where possible