### PR TITLE
[ENV-550]: Fix PS1 to work in sub shells

### DIFF
--- a/.config/ksh/kshrc
+++ b/.config/ksh/kshrc
@@ -4,15 +4,6 @@
 # Korn shell configuration
 #
 
-# Catch non-ksh sessions
-case "$0" in
-	# Early return if the ksh(1) instance isn't interactive
-	*ksh*) [[ $- = *i* ]] || return ;;
-
-	# Early return if not run by ksh(1)
-	*) return ;;
-esac
-
 # Configure history
 HISTFILE="${XDG_CACHE_HOME}/history.${0##*/}"
 HISTSIZE=2048

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -4,6 +4,18 @@
 # Session shell configuration
 #
 
+# Helper to calculate PS1
+_PS1_DIR() {
+	case "$PWD" in
+		"$HOME") echo "~"          ;;
+		"/")     echo "/"          ;;
+		*)       echo "${PWD##*/}" ;;
+	esac
+}
+
+# Set the prompt to the current directory and a dollar sign
+export PS1='$(_PS1_DIR) $ '
+
 # Catch session shell
 case "$0" in
 	# Include kshrc in interactive ksh sessions

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#
+# Session shell configuration
+#
+
+# Catch session shell
+case "$0" in
+	# Include kshrc in interactive ksh sessions
+	*ksh*) [[ $- = *i* ]] && . "${KSHRC}" ;;
+esac
+

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -21,7 +21,7 @@ case "$0" in
 	# Include kshrc in interactive ksh sessions, within
 	# the confines of this case we can assume ksh syntax.
 	*ksh*)
-		# shellcheck disable=SC2039
+		# shellcheck disable=SC2039, source=.config/ksh/kshrc
 		if [[ $- = *i* ]] && [ "${KSHRC}" ]
 		then
 			. "${KSHRC}"

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -20,7 +20,12 @@ export PS1='$(_PS1_DIR) $ '
 case "$0" in
 	# Include kshrc in interactive ksh sessions, within
 	# the confines of this case we can assume ksh syntax.
-	# shellcheck disable=SC2039
-	*ksh*) [[ $- = *i* ]] && . "${KSHRC}" ;;
+	*ksh*)
+		# shellcheck disable=SC2039
+		if [[ $- = *i* ]] && [ "${KSHRC}" ]
+		then
+			. "${KSHRC}"
+		fi
+	;;
 esac
 

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -21,7 +21,7 @@ case "$0" in
 	# Include kshrc in interactive ksh sessions, within
 	# the confines of this case we can assume ksh syntax.
 	*ksh*)
-		# shellcheck disable=SC2039, source=.config/ksh/kshrc
+		# shellcheck disable=SC2039 source=.config/ksh/kshrc
 		if [[ $- = *i* ]] && [ "${KSHRC}" ]
 		then
 			. "${KSHRC}"

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -18,7 +18,9 @@ export PS1='$(_PS1_DIR) $ '
 
 # Catch session shell
 case "$0" in
-	# Include kshrc in interactive ksh sessions
+	# Include kshrc in interactive ksh sessions, within
+	# the confines of this case we can assume ksh syntax.
+	# shellcheck disable=SC2039
 	*ksh*) [[ $- = *i* ]] && . "${KSHRC}" ;;
 esac
 

--- a/.config/sh/shrc
+++ b/.config/sh/shrc
@@ -21,7 +21,7 @@ case "$0" in
 	# Include kshrc in interactive ksh sessions, within
 	# the confines of this case we can assume ksh syntax.
 	*ksh*)
-		# shellcheck disable=SC2039 source=.config/ksh/kshrc
+		# shellcheck disable=SC2039 source=/dev/null
 		if [[ $- = *i* ]] && [ "${KSHRC}" ]
 		then
 			. "${KSHRC}"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -100,7 +100,7 @@ jobs:
       - name: shellcheck profile
         uses: ludeeus/action-shellcheck@master
         with:
-          additional_files: .profile .kshrc
+          additional_files: .profile
 
       # Lint user aliases
       - uses: actions/checkout@v1

--- a/.profile
+++ b/.profile
@@ -75,7 +75,10 @@ export PAGER=less
 # Set KSHRC to provide ksh/mksh specific settings
 export KSHRC="${XDG_CONFIG_HOME}/ksh/kshrc"
 
-# Set ENV to provide shell specific settings
+# Set SHRC to provide POSIX generic shell settings
+export SHRC="${XDG_CONFIG_HOME}/sh/shrc"
+
+# Set ENV to provide session specific settings
 export ENV="${KSHRC}"
 
 # Fixing misbehaving Java applications

--- a/.profile
+++ b/.profile
@@ -79,7 +79,7 @@ export KSHRC="${XDG_CONFIG_HOME}/ksh/kshrc"
 export SHRC="${XDG_CONFIG_HOME}/sh/shrc"
 
 # Set ENV to provide session specific settings
-export ENV="${KSHRC}"
+export ENV="${SHRC}"
 
 # Fixing misbehaving Java applications
 export _JAVA_AWT_WM_NONREPARENTING=1

--- a/.profile
+++ b/.profile
@@ -5,6 +5,8 @@
 # ~/.profile
 #
 
+# Helper functions {{{
+
 # Helper to safely include external scripts
 include() {
 	if [ -f "$1" ]
@@ -39,6 +41,8 @@ path_add() {
 	fi
 }
 
+# Helper functions }}}
+
 # Set standard XDG directories
 export XDG_DATA_HOME="${HOME}/.local/share"
 export XDG_CONFIG_HOME="${HOME}/.config"
@@ -68,8 +72,11 @@ export EDITOR="$(command -v vi  2>/dev/null)"
 # Set PAGER to prevent use of more(1)
 export PAGER=less
 
+# Set KSHRC to provide ksh/mksh specific settings
+export KSHRC="${XDG_CONFIG_HOME}/ksh/kshrc"
+
 # Set ENV to provide shell specific settings
-export ENV="${XDG_CONFIG_HOME}/ksh/kshrc"
+export ENV="${KSHRC}"
 
 # Fixing misbehaving Java applications
 export _JAVA_AWT_WM_NONREPARENTING=1

--- a/.profile
+++ b/.profile
@@ -18,15 +18,6 @@ include() {
 	fi
 }
 
-# Helper to calculate PS1
-_PS1_DIR() {
-	case "$PWD" in
-		"$HOME") echo "~"          ;;
-		"/")     echo "/"          ;;
-		*)       echo "${PWD##*/}" ;;
-	esac
-}
-
 # Helper to add executables to $PATH
 path_add() {
 	# If the directory exists, add it to PATH
@@ -61,9 +52,6 @@ path_add "scripts"
 
 # Add pfetch to PATH
 path_add "pfetch"
-
-# Set the prompt to the current directory and a dollar sign
-export PS1='$(_PS1_DIR) $ '
 
 # Set editor commands.
 export VISUAL="$(command -v vim 2>/dev/null)"

--- a/.profile
+++ b/.profile
@@ -59,7 +59,7 @@ path_add "scripts"
 path_add "pfetch"
 
 # Set the prompt to the current directory and a dollar sign
-export PS1="$(_PS1_DIR) $ "
+export PS1='$(_PS1_DIR) $ '
 
 # Set editor commands.
 export VISUAL="$(command -v vim 2>/dev/null)"


### PR DESCRIPTION
# Resolves #550

## Changes

1. Add `.config/sh/shrc`
2. Set `.config/sh/shrc` as `ENV`
3. Move `PS1` logic into `.config/sh/shrc`
4. Move ksh detection logic into  `.config/sh/shrc`