### PR TITLE
[EDT-668]: Mark .editorconfig as vendor code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,8 +16,8 @@
 # The `.local/share/` ddirectory contains vendor configs
 .local/share/** linguist-vendored
 
-# Report `.editorconfig` as editor configuration not just INI
-.editorconfig linguist-language=EditorConfig
+# Report `.editorconfig` as vendored to hide INI as main language.
+.editorconfig linguist-vendored
 
 # Don't report repo specific git configurations (not true dotfiles)
 .gitattributes linguist-vendored


### PR DESCRIPTION
# Resolves #668