### PR TITLE
[GIT]: Mark .config/templates as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,6 @@
 .config/git/config linguist-language=Git-Config
 
 # Report template directory as vendored code
-.config/template linguist-vendored
+.config/template/** linguist-vendored
 
 # GitHub linguist setting }}}


### PR DESCRIPTION
# Resolves #800
[![GitHub branch checks state](https://img.shields.io/github/workflow/status/yuri-norwood/dotfiles/Lint/800-git-mark-config-templates-as-vendored?label=Lint)](https://github.com/yuri-norwood/dotfiles/tree/800-git-mark-config-templates-as-vendored)
[![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/state/yuri-norwood/dotfiles/800?label=%23800)](https://github.com/yuri-norwood/dotfiles/issues/800)